### PR TITLE
Change links for documentation on bypass.beerpsi.me

### DIFF
--- a/bypassTweaks/a-bypass.json
+++ b/bypassTweaks/a-bypass.json
@@ -1,5 +1,5 @@
 {
-  "guide": "https://bypass.beerpsi.me/#/tools/tweaks?id=a-bypass",
+  "guide": "https://bypass.beerpsi.me/tools/tweaks/#a-bypass",
   "repository": {
     "uri": "https://beerpsi.me/sharerepo/?repo=https://repo.co.kr"
   },

--- a/bypassTweaks/choicy.json
+++ b/bypassTweaks/choicy.json
@@ -1,5 +1,5 @@
 {
-  "guide": "https://bypass.beerpsi.me/#/tools/non-bypasses?id=choicy",
+  "guide": "https://bypass.beerpsi.me/tools/non-bypasses/#choicy",
   "repository": {
     "uri": "https://beerpsi.me/sharerepo/?repo=https://opa334.github.io"
   },

--- a/bypassTweaks/flyjb-x.json
+++ b/bypassTweaks/flyjb-x.json
@@ -1,5 +1,5 @@
 {
-  "guide": "https://bypass.beerpsi.me/#/tools/tweaks?id=flyjb-amp-flyjb-x",
+  "guide": "https://bypass.beerpsi.me/tools/tweaks/#flyjb--flyjb-x",
   "repository": {
     "uri": "https://beerpsi.me/sharerepo/?repo=https://repo.xsf1re.kr"
   },

--- a/bypassTweaks/flyjb.json
+++ b/bypassTweaks/flyjb.json
@@ -1,5 +1,5 @@
 {
-  "guide": "https://bypass.beerpsi.me/#/tools/tweaks?id=flyjb-amp-flyjb-x",
+  "guide": "https://bypass.beerpsi.me/tools/tweaks/#flyjb--flyjb-x",
   "repository": {
     "uri": "https://beerpsi.me/sharerepo/?repo=https://repo.xsf1re.kr"
   },

--- a/bypassTweaks/hestia.json
+++ b/bypassTweaks/hestia.json
@@ -1,5 +1,5 @@
 {
-  "guide": "https://bypass.beerpsi.me/#/tools/tweaks?id=hestia",
+  "guide": "https://bypass.beerpsi.me/tools/tweaks/#hestia",
   "repository": {
     "uri": "https://beerpsi.me/sharerepo/?repo=https://repo.packix.com"
   },

--- a/bypassTweaks/hidejb.json
+++ b/bypassTweaks/hidejb.json
@@ -1,5 +1,5 @@
 {
-  "guide": "https://bypass.beerpsi.me/#/tools/tweaks?id=shadow",
+  "guide": "https://bypass.beerpsi.me/tools/tweaks/#shadow",
   "repository": {
     "uri": "https://beerpsi.me/sharerepo/?repo=https://apt.thebigboss.org/repofiles/cydia"
   },

--- a/bypassTweaks/ihide.json
+++ b/bypassTweaks/ihide.json
@@ -1,5 +1,5 @@
 {
-  "guide": "https://bypass.beerpsi.me/#/tools/tweaks?id=ihide",
+  "guide": "https://bypass.beerpsi.me/tools/tweaks/#ihide",
   "repository": {
     "uri": "https://beerpsi.me/sharerepo/?repo=https://repo.kc57.com/"
   },

--- a/bypassTweaks/kernbypass.json
+++ b/bypassTweaks/kernbypass.json
@@ -1,5 +1,5 @@
 {
-  "guide": "https://bypass.beerpsi.me/#/tools/kernel-level?id=kernbypass",
+  "guide": "https://bypass.beerpsi.me/tools/kernel-level/#kernbypass",
   "notes": "iOS 12.0 - 14.2. Exercise caution when using kernel-level bypasses.",
   "repository": {
     "uri": "https://repo.xsf1re.kr"

--- a/bypassTweaks/liberty-lite-(beta).json
+++ b/bypassTweaks/liberty-lite-(beta).json
@@ -1,5 +1,5 @@
 {
-  "guide": "https://bypass.beerpsi.me/#/tools/tweaks?id=liberty-lite-beta",
+  "guide": "https://bypass.beerpsi.me/tools/tweaks/#liberty-lite-beta",
   "notes": "Not working on unc0ver (14.4+).",
   "repository": {
     "uri": "https://beerpsi.me/sharerepo/?repo=https://ryleyangus.com/repo"

--- a/bypassTweaks/libhooker-configurator.json
+++ b/bypassTweaks/libhooker-configurator.json
@@ -1,5 +1,5 @@
 {
-  "guide": "https://bypass.beerpsi.me/#/tools/non-bypasses?id=libhooker-configurator",
+  "guide": "https://bypass.beerpsi.me/tools/non-bypasses/#libhooker-configurator",
   "repository": {
     "uri": "https://beerpsi.me/sharerepo/?repo=https://repo.theodyssey.dev"
   },

--- a/bypassTweaks/shadow.json
+++ b/bypassTweaks/shadow.json
@@ -1,5 +1,5 @@
 {
-  "guide": "https://bypass.beerpsi.me/#/tools/tweaks?id=shadow",
+  "guide": "https://bypass.beerpsi.me/tools/tweaks/#shadow",
   "repository": {
     "uri": "https://beerpsi.me/sharerepo/?repo=https://ios.jjolano.me"
   },

--- a/bypassTweaks/vnodebypass.json
+++ b/bypassTweaks/vnodebypass.json
@@ -1,5 +1,5 @@
 {
-  "guide": "https://bypass.beerpsi.me/#/tools/kernel-level?id=vnodebypass",
+  "guide": "https://bypass.beerpsi.me/tools/kernel-level/#vnodebypass",
   "notes": "Exercise caution when using kernel-level bypasses. Not working on unc0ver (14.6+) due to libkrw needing an update.",
   "repository": {
     "uri": "https://beerpsi.me/sharerepo/?repo=https://cydia.ichitaso.com"


### PR DESCRIPTION
We migrated to our Hugo website which uses a different URL hierarchy structure. This PR changes links to match the new location.

Also, I suggest putting the canonical URL of the repo in `repository.url`, and the sharerepo link in `repository.shareurl`. This will probably be a breaking change, but will be more useful if someone wants the canonical links.