### PR TITLE
[bypasses] Removes SxBypass

### DIFF
--- a/bypassApps/com.nianticlabs.pokemongo.json
+++ b/bypassApps/com.nianticlabs.pokemongo.json
@@ -8,9 +8,6 @@
       "name": "vnodebypass"
     },
     {
-      "name": "SxBypass"
-    },
-    {
       "notes": "If you're not willing to use a kernel bypass, try spamming the home bar like in [this video](https://cdn.discordapp.com/attachments/911121069132382250/933587034302476328/RPReplay_Final1642654374.mp4)"
     }
   ]

--- a/bypassTweaks/sxbypass.json
+++ b/bypassTweaks/sxbypass.json
@@ -1,7 +1,0 @@
-{
-  "notes": "Only works with Cydia Substrate/Substitute (checkra1n/unc0ver), not libhooker.",
-  "repository": {
-    "uri": "https://beerpsi.me/sharerepo/?repo=https://repo.sx-pokego.xyz"
-  },
-  "name": "SxBypass"
-}


### PR DESCRIPTION
### Rationale
- Bypass only works with specific hooking libraries (Cydia Substrate/Substitute)
- Enable cheats
- ~~A closed-source fork of vnodebypass, which is a GPL3 tweak.~~
- vnodebypass works fine, so we're not missing out on anything.