### PR TITLE
fix p0laris support

### DIFF
--- a/jailbreakFiles/legacy/p0laris.js
+++ b/jailbreakFiles/legacy/p0laris.js
@@ -24,20 +24,22 @@ module.exports = {
     color: "#202020",
     icon: "/assets/images/jb-icons/p0laris.png",
     type: "Semi-untethered",
-    firmwares: ["9.3.5","9.3.6"]
+    firmwares: ["9.3","9.3.6"]
   },
   compatibility: [
     {
       firmwares: [
+        "13E236", // 9.3 (iPad 2 Wi-Fi + 3G)
+        "13E237", // 9.3 (other)
+        "13E238", // 9.3.1
+        "13F69", // 9.3.2
+        "13G34", // 9.3.3
+        "13G35", // 9.3.4
         "13G36", // 9.3.5
         "13G37", // 9.3.6
       ],
       devices: [
         "iPhone4,1", // iPhone 4S, A5
-        "iPhone5,1", // iPhone 5 (GSM), A6
-        "iPhone5,2", // iPhone 5 (CDMA), A6
-        "iPhone5,3", // iPhone 5c (GSM), A6
-        "iPhone5,4", // iPhone 5c (CDMA), A6
         "iPad2,1", // iPad 2 Wi-Fi, A5
         "iPad2,2", // iPad 2 Wi-Fi + 3G (GSM), A5
         "iPad2,3", // iPad 2 Wi-Fi + 3G (CDMA), A5
@@ -48,9 +50,6 @@ module.exports = {
         "iPad3,1", // iPad (3rd generation) Wi-Fi, A5X
         "iPad3,2", // iPad (3rd generation) Wi-Fi + Cellular (VZ), A5X
         "iPad3,3", // iPad (3rd generation) Wi-Fi + Cellular, A5X
-        "iPad3,4", // iPad (4th generation) Wi-Fi, A6X
-        "iPad3,5", // iPad (4th generation) Wi-Fi + Cellular, A6X
-        "iPad3,6", // iPad (4th generation) Wi-Fi + Cellular (MM), A6X
         "iPod5,1", // iPod touch (5th generation), A5
       ]
     },


### PR DESCRIPTION
ight, so I know that I technically don't have hard proof p0laris doesn't work on A6 and works on 9.3-9.3.4 as well, but I've observed it for some time now and the hardcoded offsets I see seem to be for 9.3.X - I've took a look through iOS 9.3.X's kernelcache and confirmed that the hardcoded offsets I could find it uses, such as the hardcoded allproc offset, proc_ucred offset, and _kernel_pmap, are definitely the same on 9.3-9.3.6 and NOT the correct offsets for previous firmwares. I actually mentioned this to spv, and he seemed to confirm this with me. Also, the _kernel_pmap is hardcoded to 0x003F6454, which would only be affective for 9.3.X A5/A5X, as for A6/A6X it's 0x003FE454, hence the pmap patch wouldn't work. It seems like for the rest I could find, offsets aren't hardcoded and instead the patchfinder is used to find them so they should work without trouble. Therefore, I can say that A6/A6X definitely doesn't work with p0laris at the current moment, at least not until spv either makes a patchfinder or adds A6/A6X's hardcoded offset.