### PR TITLE
Add release notes and security notes links for macOS 12.x

### DIFF
--- a/iosFiles/macOS/21x - 12.x/21A559.json
+++ b/iosFiles/macOS/21x - 12.x/21A559.json
@@ -3,6 +3,8 @@
     "version": "12.0.1",
     "build": "21A559",
     "released": "2021-10-25",
+    "release_notes": "https://support.apple.com/HT212585#macos1201",
+    "security_notes": "https://support.apple.com/HT212869",
     "deviceMap": [
         "MacBookAir10,1",
         "MacBookPro17,1",

--- a/iosFiles/macOS/21x - 12.x/21C52.json
+++ b/iosFiles/macOS/21x - 12.x/21C52.json
@@ -3,6 +3,8 @@
     "version": "12.1",
     "build": "21C52",
     "released": "2021-12-13",
+    "release_notes": "https://support.apple.com/HT212585#macos121",
+    "security_notes": "https://support.apple.com/HT212978",
     "deviceMap": [
         "MacBookAir10,1",
         "MacBookPro17,1",

--- a/iosFiles/macOS/21x - 12.x/21D49.json
+++ b/iosFiles/macOS/21x - 12.x/21D49.json
@@ -3,6 +3,8 @@
     "version": "12.2",
     "build": "21D49",
     "released": "2022-01-26",
+    "release_notes": "https://support.apple.com/HT212585#macos122",
+    "security_notes": "https://support.apple.com/HT213054",
     "deviceMap": [
         "MacBookAir10,1",
         "MacBookPro17,1",

--- a/iosFiles/macOS/21x - 12.x/21D62.json
+++ b/iosFiles/macOS/21x - 12.x/21D62.json
@@ -3,6 +3,8 @@
     "version": "12.2.1",
     "build": "21D62",
     "released": "2022-02-10",
+    "release_notes": "https://support.apple.com/HT212585#macos1221",
+    "security_notes": "https://support.apple.com/HT213092",
     "deviceMap": [
         "MacBookAir10,1",
         "MacBookPro17,1",

--- a/iosFiles/macOS/21x - 12.x/21E230.json
+++ b/iosFiles/macOS/21x - 12.x/21E230.json
@@ -3,6 +3,8 @@
     "version": "12.3",
     "build": "21E230",
     "released": "2022-03-14",
+    "release_notes": "https://support.apple.com/HT212585#macos123",
+    "security_notes": "https://support.apple.com/HT213183",
     "deviceMap": [
         "Mac13,1",
         "Mac13,2",

--- a/iosFiles/macOS/21x - 12.x/21E258.json
+++ b/iosFiles/macOS/21x - 12.x/21E258.json
@@ -3,6 +3,8 @@
     "version": "12.3.1",
     "build": "21E258",
     "released": "2022-03-31",
+    "release_notes": "https://support.apple.com/HT212585#macos1231",
+    "security_notes": "https://support.apple.com/HT213220",
     "deviceMap": [
         "Mac13,1",
         "Mac13,2",

--- a/iosFiles/macOS/21x - 12.x/21F79.json
+++ b/iosFiles/macOS/21x - 12.x/21F79.json
@@ -3,6 +3,8 @@
     "version": "12.4",
     "build": "21F79",
     "released": "2022-05-16",
+    "release_notes": "https://support.apple.com/HT212585#macos124",
+    "security_notes": "https://support.apple.com/HT213257",
     "deviceMap": [
         "Mac13,1",
         "Mac13,2",


### PR DESCRIPTION
I did macOS12 first because I'm testing generation of the [Firmware/Mac/12.x](https://www.theiphonewiki.com/wiki/Firmware/Mac/12.x) wiki page from appledb data (I thought that would be an easy one to start with). I will add links for other OSs later, if there's agreement with the JSON format.