### PR TITLE
Add SHA-1 hash for macOS 12.4

### DIFF
--- a/iosFiles/macOS/21x - 12.x/21F79.json
+++ b/iosFiles/macOS/21x - 12.x/21F79.json
@@ -32,6 +32,9 @@
                 "iMac21,2"
             ],
             "type": "ipsw",
+            "hashes": {
+                "sha1": "b5553b62da22e5fdbab2b56b6eb1fb74b58555ac"
+            },
             "links": [
                 {
                     "url": "https://updates.cdn-apple.com/2022SpringFCS/fullrestores/012-06874/9CECE956-D945-45E2-93E9-4FFDC81BB49A/UniversalMac_12.4_21F79_Restore.ipsw",


### PR DESCRIPTION
macOS 12.4 (21F79) was missing hashes. Added SHA-1, taken from Apple's `macOSIPSW.xml`.