### PR TITLE
openpwnage Build 8 + other

### DIFF
--- a/jailbreakFiles/legacy/openpwnage.js
+++ b/jailbreakFiles/legacy/openpwnage.js
@@ -19,12 +19,11 @@ module.exports = {
         pkgman: "cydia",
       }
     ],
-    latestVer: "Beta Build 7",
+    latestVer: "Beta Build 8",
     color: "#faf4f7",
     jailbreaksmeapp: true,
     type: "Semi-untethered",
     firmwares: ["8.4b4","9.3.6"]
-    notes: "Substrate only works on iOS 9"
   },
   compatibility: [
     {

--- a/jailbreakFiles/legacy/pangu9.js
+++ b/jailbreakFiles/legacy/pangu9.js
@@ -12,6 +12,13 @@ module.exports = {
       url: "https://www.theiphonewiki.com/wiki/Pangu9",
       external: true
     },
+    guide: [
+      {
+        name: "Installing Pangu9",
+        url: "/installing-pangu9/",
+        pkgman: "cydia",
+      }
+    ],
     type: "Untethered",
     firmwares: ["9.0","9.1"],
     latestVer: "1.3.2 (Windows)\n1.1.1 (macOS)\n1.0.0 (Apple TV 4)",

--- a/jailbreakFiles/legacy/ppjailbreak.js
+++ b/jailbreakFiles/legacy/ppjailbreak.js
@@ -1,5 +1,6 @@
 module.exports = {
   name: "PPJailbreak",
+  priority: 7,
   info: {
     wiki: {
       name: "theiphonewiki.com/wiki/PPJailbreak",
@@ -7,7 +8,8 @@ module.exports = {
       external: true
     },
     type: "Untethered",
-    firmwares: ["8.0","8.4"]
+    firmwares: ["8.0","8.4"],
+    notes: "Not Functional on OTA updated devices"
   },
   compatibility: [
     {

--- a/jailbreakFiles/legacy/taig.js
+++ b/jailbreakFiles/legacy/taig.js
@@ -1,6 +1,6 @@
 module.exports = {
   name: "TaiG",
-  priority: 0,
+  priority: 10,
   info: {
     wiki: {
       name: "theiphonewiki.com/wiki/TaiG",


### PR DESCRIPTION
Prioritized PPJailbreak over TaiG. While PPJailbreak doesn't work on OTA Updated devices, that's still more functional than TaiG. I also added a note towards TaiG. Since openpwnage now has fully working Substrate, it's prioritized over PPJailbreak if 8.4. This shouldn't prioritize openpwnage over anything else except PPJailbreak.